### PR TITLE
Yardforce 500b UART pin definition fix

### DIFF
--- a/stm32/ros_usbnode/src/blademotor.c
+++ b/stm32/ros_usbnode/src/blademotor.c
@@ -112,7 +112,7 @@ void BLADEMOTOR_Init(void)
 #endif
     
     // RX
-    GPIO_InitStruct.Pin = BLADEMOTOR_USART_RX_PIN;
+    GPIO_InitStruct.Pin = BLADEMOTOR_USART_TX_PIN|BLADEMOTOR_USART_RX_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
@@ -122,7 +122,7 @@ void BLADEMOTOR_Init(void)
     HAL_GPIO_Init(BLADEMOTOR_USART_RX_PORT, &GPIO_InitStruct);
 
     // TX
-    GPIO_InitStruct.Pin = BLADEMOTOR_USART_TX_PIN;
+    GPIO_InitStruct.Pin = BLADEMOTOR_USART_TX_PIN|BLADEMOTOR_USART_RX_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
 #if BOARD_YARDFORCE500_VARIANT_B

--- a/stm32/ros_usbnode/src/drivemotor.c
+++ b/stm32/ros_usbnode/src/drivemotor.c
@@ -148,7 +148,7 @@ void DRIVEMOTOR_Init(void){
     DRIVEMOTORS_USART_USART_CLK_ENABLE();
     
     // RX
-    GPIO_InitStruct.Pin = DRIVEMOTORS_USART_RX_PIN;
+    GPIO_InitStruct.Pin = DRIVEMOTORS_USART_TX_PIN|DRIVEMOTORS_USART_RX_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;
@@ -158,7 +158,7 @@ void DRIVEMOTOR_Init(void){
     HAL_GPIO_Init(DRIVEMOTORS_USART_RX_PORT, &GPIO_InitStruct);
 
     // TX
-    GPIO_InitStruct.Pin = DRIVEMOTORS_USART_TX_PIN;
+    GPIO_InitStruct.Pin = DRIVEMOTORS_USART_TX_PIN|DRIVEMOTORS_USART_RX_PIN;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     // GPIO_InitStruct.Pull = GPIO_PULLUP;
     GPIO_InitStruct.Speed = GPIO_SPEED_HIGH;


### PR DESCRIPTION
For DMA interrupt to work, both pins have to be defined together in the STM32F4, this change is tested on 500B hardware and results in tach & ticks coming back from blade/drive motors